### PR TITLE
fix, refactor:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-data/input
+data/*

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ def main():
     gh_ext = github_extractor.Extractor(cfg_obj)
     print(f"{tab}Extractor initialization complete!\n")
 
-    print("Getting issue data...")
+    print("Mining repo data...")
     gh_ext.get_repo_issues_data()
     print(f"\n{tab}Issue data complete!\n")
 

--- a/repo_extractor/conf.py
+++ b/repo_extractor/conf.py
@@ -4,17 +4,6 @@ import sys
 import cerberus
 
 
-def _access_dict_at_key(dictionary, key):
-    try:
-        val = dictionary[key]
-
-    except KeyError:
-        print(f"Key '{key}' does not exist!")
-        sys.exit(1)
-
-    return val
-
-
 class Cfg:
     """Object which holds all of the configuration for the extractor class."""
 
@@ -52,20 +41,7 @@ class Cfg:
             list|int|str: value in the top level of the cfg
             dict associated with the given key
         """
-        return _access_dict_at_key(self.cfg_dict, key)
-
-    def get_repo_data_cfg_val(self, key: str):
-        """
-        Return the value mapped to the given key in the "repo_data" subdict.
-
-        Args:
-            key (str): associated key for desired val.
-
-        Returns:
-            list|int|str: value in the top level of the cfg
-            dict associated with the given key
-        """
-        return _access_dict_at_key(self.cfg_dict["repo_data"], key)
+        return self.cfg_dict[key]
 
     def set_cfg_val(self, key: str, val) -> None:
         """

--- a/repo_extractor/schema.py
+++ b/repo_extractor/schema.py
@@ -199,7 +199,7 @@ cmd_tbl: dict = {
         "message": _get_commit_msg,
         "sha": _get_commit_sha,
     },
-    "issue": {
+    "issues": {
         "body": _get_body,
         "closed_at": _get_closed_time,
         "created_at": _get_created_time,
@@ -221,7 +221,7 @@ _str_type = {"type": "string"}
 #
 # [*_] = create a list from the keys of the unpacked
 #        dict comprehension operand dict, e.g. _cmd_tbl_dict
-issue_fields_schema = {
+issues_fields_schema = {
     key: {
         "allowed": [*_],
         "schema": _str_type,
@@ -237,17 +237,12 @@ cfg_schema: dict = {
     "auth_path": _str_type,
     "repo": _str_type,
     "output_path": _str_type,
-    "repo_data": {
-        "type": "dict",
-        "schema": {
-            **issue_fields_schema,
-            "state": {**_str_type, "allowed": ["closed", "open"]},
-            "range": {
-                "nullable": True,
-                "min": [0, 0],
-                "schema": {"type": "integer"},
-                "type": "list",
-            },
-        },
+    **issues_fields_schema,
+    "state": {**_str_type, "allowed": ["closed", "open"]},
+    "range": {
+        "nullable": True,
+        "min": [0, 0],
+        "schema": {"type": "integer"},
+        "type": "list",
     },
 }


### PR DESCRIPTION
fix:
- revert change to iteration inside of
  get_repo_issues_data()
	- iterate over indices instead of item
	  numbers. Iterating over issue numbers
	  means that we have to increment index
	  and update the variable containing the
	  current item. This can result in
	  IndexError exceptions.

	- use binary search to find both start and
	  end indices. If the index returned is the
	  same when we are asking for one item, that
	  means that the end item number we have
	  chosen either doesn't exist or is not
	  available for that state, e.g. it's an
	  open issue when we have chosen to mine
	  closed issues.

- remove nesting of repo cfg ("repo_data"
  subkey) in configuration JSON schema
	- getting sanitized end of range returned
	  range given in configuration, not cleaned
	  value. This is because we were cleaning
	  the value in a nested dict but attempting
	  to access the value in the top-level cfg
	  dict.

refactor:
- Remove several unnecessary methods